### PR TITLE
Add acm-dns-validated module

### DIFF
--- a/.changeset/kind-rats-lay.md
+++ b/.changeset/kind-rats-lay.md
@@ -1,0 +1,5 @@
+---
+'pulumi-acm-dns-validated-cert': minor
+---
+
+Initial release of pulumi-acm-dns-validated-cert

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ],
     "scripts": {
         "build": "yarn tsc -b",
-        "test": "yarn jest --passWithNoTests",
+        "test": "PULUMI_TEST_MODE=true PULUMI_NODEJS_STACK=test PULUMI_NODEJS_PROJECT=test yarn jest --passWithNoTests",
         "lint": "eslint --ext .js,.ts .",
         "verify": "yarn build && yarn test && yarn lint",
         "changeset": "changeset",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "homepage": "https://github.com/sevenwestmedia-labs/pulumi#readme",
     "dependencies": {
         "@changesets/cli": "^2.4.0",
+        "@pulumi/aws": "^1.11.0",
         "@pulumi/awsx": "^0.18.13",
         "@pulumi/pulumi": "^1.5.2",
         "@types/enzyme": "^3.10.3",

--- a/packages/acm-dns-validated-cert/.gitignore
+++ b/packages/acm-dns-validated-cert/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/packages/acm-dns-validated-cert/README.md
+++ b/packages/acm-dns-validated-cert/README.md
@@ -1,0 +1,56 @@
+# acm-dns-validated-cert
+
+This module:
+
+-   creates a certificate in AWS Certificate Manager (ACM)
+-   creates associated DNS validation records in Route53
+-   waits for the DNS records to be validated, and the certificate to be issued.
+
+# Usage
+
+This example will create an ACM certificate, and create validation records in
+the 'example.com' Route53 zone.
+
+```
+import * as acmCert from 'pulumi-acm-dns-validated-cert'
+
+const cert = new acmCert.ACMCert('example-cert', {
+    subject: 'www.example.com',
+    zoneName: 'example.com',
+})
+
+export const certArn = cert.certificateArn
+```
+
+If preferred, you can specify the zoneId instead. You can also use
+`subjectAlternativeNames` to create a certificate with multiple domains:
+
+```
+const cert = new acmCert.ACMCert('example-cert', {
+    subject: 'example.com',
+    subjectAlternativeNames: [
+        'www.example.com',
+    ]
+    zoneId: 'MY-ZONE-ID',
+})
+```
+
+Sometimes, you need to create the certificate in a non-default region. Pulumi
+allows you to specify your own provider and pass it in using `opts`. The next
+example creates the certificate in the `us-east-1` region:
+
+```
+import * as aws from '@pulumi/aws'
+
+const useast1 = new aws.Provider('us-east-1', {
+    region: 'us-east-1'
+})
+
+const cert = new acmCert.ACMCert('example-cert', {
+    subject: 'example.com',
+    zoneId: 'example.com',
+},
+{
+    provider: useast1,
+})
+```

--- a/packages/acm-dns-validated-cert/package.json
+++ b/packages/acm-dns-validated-cert/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "pulumi-acm-dns-validated-cert",
+    "peerDependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/aws": "^1.0.0"
+    },
+    "version": "0.0.0",
+    "description": "Creates an AWS Certificate Manager (ACM) cert, validated using Route53 DNS records",
+    "main": "dist/index.js",
+    "author": "Seven West Media WA",
+    "license": "MIT",
+    "dependencies": {}
+}

--- a/packages/acm-dns-validated-cert/src/index.ts
+++ b/packages/acm-dns-validated-cert/src/index.ts
@@ -27,7 +27,7 @@ const min = <T>(x: T, y: T): T => (x < y ? x : y)
 const abs = (x: number): number => (x < 0 ? -x : x)
 
 // produce a range of integers between n and m
-const range = (n: number, m: number = 0): number[] =>
+const range = (n: number, m = 0): number[] =>
     [...Array.from(Array(abs(n - m)).keys())].map(x => x + min(n, m))
 
 export class ACMCert extends pulumi.ComponentResource {

--- a/packages/acm-dns-validated-cert/src/index.ts
+++ b/packages/acm-dns-validated-cert/src/index.ts
@@ -100,7 +100,8 @@ export class ACMCert extends pulumi.ComponentResource {
                         },
                         {
                             ...opts,
-                            parent: this.certificate,
+                            parent: this,
+                            dependsOn: this.certificate,
                             deleteBeforeReplace: true, // prevent duplicate records on update
                         },
                     ),
@@ -116,7 +117,8 @@ export class ACMCert extends pulumi.ComponentResource {
             },
             {
                 ...opts,
-                parent: this.certificate,
+                parent: this,
+                dependsOn: [this.certificate, ...this.certValidationRecords],
             },
         )
 

--- a/packages/acm-dns-validated-cert/src/index.ts
+++ b/packages/acm-dns-validated-cert/src/index.ts
@@ -1,0 +1,116 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as aws from '@pulumi/aws'
+
+export interface ZoneNameArgs {
+    zoneName?: string
+}
+
+export interface ZoneIdArgs {
+    zoneId?: string
+}
+
+export interface CommonArgs {
+    name?: string | pulumi.Input<string>
+    subject: string | pulumi.Input<string>
+    subjectAlternativeNames?: string[]
+}
+
+type ACMCertArgs = ZoneIdArgs & ZoneNameArgs & CommonArgs
+
+export class ACMCert extends pulumi.ComponentResource {
+    public readonly certificate: aws.acm.Certificate
+    public readonly zoneId: string | pulumi.Input<string>
+    public readonly certificateValidation: aws.acm.CertificateValidation
+    public readonly certificateArn: pulumi.Output<string>
+
+    constructor(
+        name: string,
+        private args: ACMCertArgs,
+        opts?: pulumi.ResourceOptions,
+    ) {
+        super('ACMCert', name, {}, opts)
+
+        const selectedName = args.name ? args.name : name
+
+        if (args.zoneId) {
+            this.zoneId = args.zoneId
+        } else if (args.zoneName) {
+            this.zoneId = pulumi
+                .output(
+                    aws.route53.getZone(
+                        {
+                            name: args.zoneName,
+                        },
+                        {
+                            ...opts,
+                            parent: this,
+                            async: true,
+                        },
+                    ),
+                )
+                .apply((zone: aws.route53.GetZoneResult) => zone.id)
+        } else {
+            throw new Error(
+                'You must set either zoneName or zoneId when creating a new ACMCert',
+            )
+        }
+
+        this.certificate = new aws.acm.Certificate(
+            `${selectedName}-cert`,
+            {
+                domainName: args.subject,
+                subjectAlternativeNames: args.subjectAlternativeNames,
+                validationMethod: 'DNS',
+            },
+            {
+                ...opts,
+                parent: this,
+            },
+        )
+
+        const numberOfUniqueDomains = [
+            ...new Set([args.subject, ...(args.subjectAlternativeNames || [])]),
+        ].length
+
+        const certValidationRecords = Array(numberOfUniqueDomains)
+            .fill(null)
+            .map(
+                (_, i) =>
+                    new aws.route53.Record(
+                        `${selectedName}-validation-record-${i}`,
+                        {
+                            name: this.certificate.domainValidationOptions[i]
+                                .resourceRecordName,
+                            records: [
+                                this.certificate.domainValidationOptions[i]
+                                    .resourceRecordValue,
+                            ],
+                            ttl: 60,
+                            type: this.certificate.domainValidationOptions[i]
+                                .resourceRecordType,
+                            zoneId: this.zoneId,
+                        },
+                        {
+                            ...opts,
+                            parent: this.certificate,
+                            deleteBeforeReplace: true, // prevent duplicate records on update
+                        },
+                    ),
+            )
+
+        this.certificateValidation = new aws.acm.CertificateValidation(
+            `${selectedName}-cert-validation`,
+            {
+                certificateArn: this.certificate.arn,
+                validationRecordFqdns: certValidationRecords.map(r => r.fqdn),
+            },
+            {
+                ...opts,
+                parent: this.certificate,
+            },
+        )
+
+        this.certificateArn = this.certificateValidation.certificateArn
+        this.registerOutputs()
+    }
+}

--- a/packages/acm-dns-validated-cert/tests/ACMCert.test.ts
+++ b/packages/acm-dns-validated-cert/tests/ACMCert.test.ts
@@ -1,0 +1,140 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as aws from '@pulumi/aws'
+import * as cert from '../src'
+
+// promise returns a resource output's value, even if it's undefined.
+// (adapted from https://www.pulumi.com/blog/unit-testing-infrastructure-in-nodejs-and-mocha/)
+export function promise<T>(output: pulumi.Output<T>): Promise<T | undefined> {
+    return (output as any).promise() as Promise<T>
+}
+
+describe('ACMCert.constructor', () => {
+    it('creates a DNS-validated certificate matching domains', async () => {
+        const myCert = new cert.ACMCert('example', {
+            subject: 'example.com',
+            subjectAlternativeNames: [
+                'www.example.com',
+                'api.example.com',
+            ].sort(),
+            zoneName: 'example.com',
+        })
+
+        const domainName = await promise(myCert.certificate.domainName)
+
+        if (domainName) {
+            expect(domainName).toEqual('example.com')
+        } else if (pulumi.runtime.isDryRun()) {
+            console.warn(
+                'Skipped myCert.certificate.domainName check' +
+                    ' (not known during pulumi dry run)',
+            )
+        }
+
+        const subjectAlternativeNames = await promise(
+            myCert.certificate.subjectAlternativeNames,
+        )
+
+        if (subjectAlternativeNames) {
+            expect(subjectAlternativeNames.sort()).toEqual(
+                ['www.example.com', 'api.example.com'].sort(),
+            )
+        } else if (pulumi.runtime.isDryRun()) {
+            console.warn(
+                'Skipped myCert.certificate.subjectAlternativeNames check' +
+                    ' (not known during pulumi dry run)',
+            )
+        }
+
+        const validationMethod = await promise(
+            myCert.certificate.validationMethod,
+        )
+
+        if (validationMethod) {
+            expect(validationMethod).toEqual('DNS')
+        } else if (pulumi.runtime.isDryRun()) {
+            console.warn(
+                'Skipped myCert.certificate.validationMethod check' +
+                    ' (not known during pulumi dry run)',
+            )
+        }
+    })
+
+    it('creates validation records for subject and subjectAlternativeNames', async () => {
+        const myCert = new cert.ACMCert('example', {
+            subject: 'example.com',
+            zoneName: 'example.com',
+        })
+
+        expect(myCert.certValidationRecords.length).toEqual(1)
+
+        const myCertWithSANs = new cert.ACMCert('example', {
+            subject: 'example.com',
+            subjectAlternativeNames: ['www.example.com', 'api.example.com'],
+            zoneName: 'example.com',
+        })
+
+        expect(myCertWithSANs.certValidationRecords.length).toEqual(3)
+    })
+
+    it('does not create duplicate validation records', async () => {
+        const myCert = new cert.ACMCert('example', {
+            subject: 'example.com',
+            subjectAlternativeNames: [
+                'example.com',
+                'www.example.com',
+                'api.example.com',
+                'api.example.com',
+            ],
+            zoneName: 'example.com',
+        })
+
+        expect(myCert.certValidationRecords.length).toEqual(3)
+    })
+
+    // throws type errors
+    it.skip('should use the provider given', async () => {
+        const usEast1 = new aws.Provider('us-east-1', { region: 'us-east-1' })
+        const myCert = new cert.ACMCert(
+            'example',
+            {
+                subject: 'example.com',
+                zoneName: 'example.com',
+            },
+            {
+                provider: usEast1,
+            },
+        )
+
+        const certificateArn = await promise(myCert.certificateArn)
+
+        if (certificateArn) {
+            expect(certificateArn).toContain('us-east-1')
+        }
+        if (pulumi.runtime.isDryRun()) {
+            console.warn(
+                'Skipped myCert.certificateArn provider check (not known' +
+                    ' during pulumi dry run)',
+            )
+        }
+    })
+
+    // this test throws, but is caught and not re-thrown by pulumi
+    it.skip('should throw an error if both zoneId and zoneName are specified', () => {
+        expect(
+            new cert.ACMCert('example', {
+                subject: 'example.com',
+                zoneId: '12345ASDF',
+                zoneName: 'example.com',
+            }),
+        ).toThrow()
+    })
+
+    // this test throws, but is caught and not re-thrown by pulumi
+    it.skip('should throw an error if neither zoneId nor zoneName are specified', () => {
+        expect(
+            new cert.ACMCert('example', {
+                subject: 'example.com',
+            }),
+        ).toThrow()
+    })
+})

--- a/packages/acm-dns-validated-cert/tsconfig.json
+++ b/packages/acm-dns-validated-cert/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.settings.json",
+    "compilerOptions": {
+        "outDir": "./dist" /* Redirect output structure to the directory. */,
+        "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    },
+    "exclude": ["dist"]
+}

--- a/packages/acm-dns-validated-cert/tsconfig.json
+++ b/packages/acm-dns-validated-cert/tsconfig.json
@@ -4,5 +4,5 @@
         "outDir": "./dist" /* Redirect output structure to the directory. */,
         "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     },
-    "exclude": ["dist"]
+    "exclude": ["dist", "tests"]
 }

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,10 @@
 # Pulumi Modules
 
 A collection of Pulumi modules we have built
+
+* [run-fargate-task](packages/run-fargate-task): run one-shot tasks in Fargate
+  and collect the results.
+
+* [acm-dns-validated-cert](packages/acm-dns-validated-cert): provides an
+  Amazon ACM certificate, validated using Route 53 records.
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,9 @@
     "references": [
         {
             "path": "./packages/run-fargate-task"
+        },
+        {
+            "path": "./packages/acm-dns-validated-cert"
         }
     ],
     "files": []

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,6 +525,18 @@
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
+"@pulumi/aws@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-1.11.0.tgz#e9255f73a0a2ee5c07f9f2d083bc5a12cc6ee5c2"
+  integrity sha512-4EHmkgUBRg+L7UlGCkpCuk+Xkrt35UvfnbJ/UNSzd8qwud+Rxyw7bWSNPmocOkVY7HzW917xAM3gNmbpj5RtvQ==
+  dependencies:
+    "@pulumi/pulumi" "^1.0.0"
+    aws-sdk "^2.0.0"
+    builtin-modules "3.0.0"
+    mime "^2.0.0"
+    read-package-tree "^5.2.1"
+    resolve "^1.7.1"
+
 "@pulumi/awsx@^0.18.13":
   version "0.18.13"
   resolved "https://registry.yarnpkg.com/@pulumi/awsx/-/awsx-0.18.13.tgz#4c5cd1f3c5bf4e5841bf48cf6feb4f4e42cab366"


### PR DESCRIPTION
This module:
* creates a certificate in AWS Certificate Manager (ACM)
* creates associated DNS validation records in Route53
* waits for the DNS records to be validated, and the certificate to be issued.

It includes support for multiple SANs, and returns the certificate ARN for use in AWS resources.

Details are in the README.md, but a here is a brief example of how it's used:

```
import * as acmCert from 'pulumi-acm-dns-validated-cert'

const cert = new acmCert.ACMCert('example-cert', {
    subject: 'www.example.com',
    zoneName: 'example.com',
})
```
